### PR TITLE
Fixed README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Usage
 ````
 var cmb, a;
 cmb = Combinatorics.power(['a','b','c']);
-cmb.each(function(a){ console.log(a) });
+cmb.forEach(function(a){ console.log(a) });
 //  []
 //  ["a"]
 //  ["b"]


### PR DESCRIPTION
Fixes #27

The forEach function was incorrectly specified as `each` in the README.
